### PR TITLE
Specify blob content type on file write

### DIFF
--- a/lib/dragonfly/azure_data_store.rb
+++ b/lib/dragonfly/azure_data_store.rb
@@ -25,6 +25,7 @@ module Dragonfly
       path = full_path(filename)
       options = {}
       options[:metadata] = content.meta if store_meta
+      options[:content_type] = content.mime_type # for Azure blob to serve the content properly
       content.file do |f|
         storage(:create_block_blob, container_name, path, f, options)
       end


### PR DESCRIPTION
By default, Azure blob has the content type `application/octet-stream`. This leads to images being downloaded when accessed via web browser instead of just being displayed. For Azure to provide a proper HTTP response, we need to specify the corresponding content type when creating a blob.